### PR TITLE
Remove unnecessary react import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { createRoot } from "react-dom/client";
 import Hello from "./Hello";
 


### PR DESCRIPTION
Since the tutorial mentions using babel's automatic runtime option in order to avoid the need of importing React on top of every .jsx file, I figured the code in index.js could be updated to match this improvement.

Btw thanks for the great tutorial!